### PR TITLE
Resource stat panel integration with SettlementResourcesService

### DIFF
--- a/SettlementTracker.Core.Tests/Data/Services/MockDefinitionRepository.cs
+++ b/SettlementTracker.Core.Tests/Data/Services/MockDefinitionRepository.cs
@@ -12,7 +12,8 @@ public class MockDefinitionRepository : IResourceDefinitionRepository
         return DefinitionPreset;
     }
 
-    public async Task<Dictionary<string, ResourceDefinition>> LoadResourceDefinitionsAsync()
+    public async Task<Dictionary<string, ResourceDefinition>> LoadResourceDefinitionsAsync(
+        CancellationToken cancellationToken = default(CancellationToken))
     {
         return DefinitionPreset;
     }
@@ -21,7 +22,8 @@ public class MockDefinitionRepository : IResourceDefinitionRepository
     {
     }
 
-    public async Task SaveResourceDefinitionsAsync(Dictionary<string, ResourceDefinition> definitions)
+    public async Task SaveResourceDefinitionsAsync(Dictionary<string, ResourceDefinition> definitions,
+        CancellationToken cancellationToken = default(CancellationToken))
     {
     }
 }

--- a/SettlementTracker.Core.Tests/Data/Services/SettlementResourcesServiceTest.cs
+++ b/SettlementTracker.Core.Tests/Data/Services/SettlementResourcesServiceTest.cs
@@ -85,14 +85,17 @@ public class SettlementResourcesServiceTest
 
         // Act
         await _service.LoadDefinitionsAsync();
-        IReadOnlyList<ResourceDefinition>? definitions = _service.GetResourceDefinitions();
+        IReadOnlyDictionary<string, ResourceDefinition> definitions = _service.GetResourceDefinitions();
 
         // Assert
-        Assert.That(definitions.Count, Is.EqualTo(2));
-        Assert.That(definitions[0].Id, Is.EqualTo("food"));
-        Assert.That(definitions[1].Id, Is.EqualTo("stone"));
-        Assert.That(definitions[0].IsConsumable, Is.True);
-        Assert.That(definitions[1].IsConsumable, Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(definitions.Count, Is.EqualTo(2));
+            Assert.That(definitions.ContainsKey("food"), Is.True);
+            Assert.That(definitions.ContainsKey("stone"), Is.True);
+            Assert.That(definitions["food"].IsConsumable, Is.True);
+            Assert.That(definitions["stone"].IsConsumable, Is.False);
+        });
     }
 
     [Test]
@@ -264,11 +267,13 @@ public class SettlementResourcesServiceTest
     }
 
     [Test]
-    public async Task TrySpendResourceAsync_WithNegativeAmount_ThrowsArgumentException()
+    public async Task TrySpendResourceAsync_WithNegativeAmount_ReturnsFalse()
     {
+        // Assert
+        bool result = await _service.TrySpendResourceAsync("wood", -5);
+
         // Act & Assert
-        Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-            async () => await _service.TrySpendResourceAsync("wood", -5));
+        Assert.That(result, Is.False);
     }
 
     // This test is skipped until ApplyDailyEffectsAsync is implemented
@@ -301,7 +306,7 @@ public class SettlementResourcesServiceTest
         // Arrange
 
         // Act
-        await _service.SaveChangesAsync();
+        await _service.SaveStateAsync();
 
         // Assert
         Assert.That(File.Exists(_stateFilePath), Is.True, "Файл состояния должен быть создан.");
@@ -332,7 +337,7 @@ public class SettlementResourcesServiceTest
 
 
         // Act
-        await _service.LoadFromFileAsync();
+        await _service.LoadStateAsync();
 
         // Assert
         IReadOnlyDictionary<string, float>? actualResources = _service.GetCurrentBalance();

--- a/SettlementTracker.Core/Repositories/IResourceDefinitionRepository.cs
+++ b/SettlementTracker.Core/Repositories/IResourceDefinitionRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using SettlementTracker.Core.Models.Definitions;
 
@@ -7,8 +8,13 @@ namespace SettlementTracker.Core.Repositories
     public interface IResourceDefinitionRepository
     {
         Dictionary<string, ResourceDefinition> LoadResourceDefinitions();
-        Task<Dictionary<string, ResourceDefinition>> LoadResourceDefinitionsAsync();
+
+        Task<Dictionary<string, ResourceDefinition>> LoadResourceDefinitionsAsync(
+            CancellationToken cancellationToken = default(CancellationToken));
+
         void SaveResourceDefinitions(Dictionary<string, ResourceDefinition> definitions);
-        Task SaveResourceDefinitionsAsync(Dictionary<string, ResourceDefinition> definitions);
+
+        Task SaveResourceDefinitionsAsync(Dictionary<string, ResourceDefinition> definitions,
+            CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/SettlementTracker.Core/Repositories/JsonDefinitionRepository.cs
+++ b/SettlementTracker.Core/Repositories/JsonDefinitionRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using SettlementTracker.Core.Models.Definitions;
 using SettlementTracker.Core.Models.Enums;
@@ -11,6 +12,7 @@ namespace SettlementTracker.Core.Repositories
         IPopulationDefinitionRepository, IJobDefinitionRepository
     {
         private readonly string _basePath;
+        private readonly string _resourcesDefinitionFile = "resourcesDefinition.json";
 
         public JsonDefinitionRepository(string basePath)
         {
@@ -22,7 +24,7 @@ namespace SettlementTracker.Core.Repositories
 
         public Dictionary<string, ResourceDefinition> LoadResourceDefinitions()
         {
-            string filePath = Path.Combine(_basePath, "resources.json");
+            string filePath = Path.Combine(_basePath, _resourcesDefinitionFile);
             if (!File.Exists(filePath))
                 // Создаем базовые ресурсы по умолчанию
                 return CreateDefaultResourceDefinitions();
@@ -38,14 +40,15 @@ namespace SettlementTracker.Core.Repositories
             return result;
         }
 
-        public async Task<Dictionary<string, ResourceDefinition>> LoadResourceDefinitionsAsync()
+        public async Task<Dictionary<string, ResourceDefinition>> LoadResourceDefinitionsAsync(
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            string filePath = Path.Combine(_basePath, "resources.json");
+            string filePath = Path.Combine(_basePath, _resourcesDefinitionFile);
             if (!File.Exists(filePath))
                 // Создаем базовые ресурсы по умолчанию
                 return CreateDefaultResourceDefinitions();
 
-            string json = await File.ReadAllTextAsync(filePath);
+            string json = await File.ReadAllTextAsync(filePath, cancellationToken);
             var definitions = JsonSerializer.Deserialize<List<ResourceDefinition>>(json);
 
             var result = new Dictionary<string, ResourceDefinition>();
@@ -58,18 +61,19 @@ namespace SettlementTracker.Core.Repositories
 
         public void SaveResourceDefinitions(Dictionary<string, ResourceDefinition> definitions)
         {
-            string filePath = Path.Combine(_basePath, "resources.json");
+            string filePath = Path.Combine(_basePath, _resourcesDefinitionFile);
             string json =
                 JsonSerializer.Serialize(definitions.Values, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(filePath, json);
         }
 
-        public async Task SaveResourceDefinitionsAsync(Dictionary<string, ResourceDefinition> definitions)
+        public async Task SaveResourceDefinitionsAsync(Dictionary<string, ResourceDefinition> definitions,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            string filePath = Path.Combine(_basePath, "resources.json");
+            string filePath = Path.Combine(_basePath, _resourcesDefinitionFile);
             string json =
                 JsonSerializer.Serialize(definitions.Values, new JsonSerializerOptions { WriteIndented = true });
-            await File.WriteAllTextAsync(filePath, json);
+            await File.WriteAllTextAsync(filePath, json, cancellationToken);
         }
 
 

--- a/SettlementTracker.Core/Services/ISettlementResourcesService.cs
+++ b/SettlementTracker.Core/Services/ISettlementResourcesService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using SettlementTracker.Core.Managers;
 using SettlementTracker.Core.Models.Definitions;
@@ -12,18 +13,28 @@ namespace SettlementTracker.WebInterface.Data.Services
         ///     Loads JSON from standard file path.
         /// </summary>
         /// <returns></returns>
-        Task LoadDefinitionsAsync();
+        Task LoadDefinitionsAsync(CancellationToken cancellationToken = default(CancellationToken));
 
-        IReadOnlyList<ResourceDefinition> GetResourceDefinitions();
+        Task SaveStateAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task LoadStateAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        IReadOnlyDictionary<string, ResourceDefinition> GetResourceDefinitions();
         IReadOnlyDictionary<string, float> GetCurrentBalance();
 
 
-        Task AddResourceAsync(string resourceId, float amount);
+        Task SetResourceAsync(string resourceId, float amount,
+            CancellationToken cancellationToken = default(CancellationToken));
 
-        Task<bool> TrySpendResourceAsync(string resourceId, float amount);
+        Task AddResourceAsync(string resourceId, float amount,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        Task<bool> TrySpendResourceAsync(string resourceId, float amount,
+            CancellationToken cancellationToken = default(CancellationToken));
 
         bool CanSpend(string resourceId, float amount);
         event EventHandler<ResourcesChangedEventArgs> ResourcesChanged;
-        Task ApplyDailyEffectsAsync(IEnumerable<ResourceEffect> dailyEffects);
+
+        Task ApplyDailyEffectsAsync(IEnumerable<ResourceEffect> dailyEffects,
+            CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/SettlementTracker.Core/Services/SettlementResourcesService.cs
+++ b/SettlementTracker.Core/Services/SettlementResourcesService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using SettlementTracker.Core.Managers;
 using SettlementTracker.Core.Models.Definitions;
@@ -18,20 +19,22 @@ namespace SettlementTracker.Core.Services
         private readonly string _stateFilePath;
         private Dictionary<string, ResourceDefinition> _definitions;
         private Dictionary<string, float> _resources;
+        private readonly string _directoryName;
 
         public SettlementResourcesService(IResourceDefinitionRepository definitionRepository,
             string stateFilePath = "State\\resources.json")
         {
             _definitionRepository = definitionRepository;
             _stateFilePath = stateFilePath;
+            _directoryName = Path.GetDirectoryName(Path.GetFullPath(_stateFilePath));
             _resources = new Dictionary<string, float>();
             _definitions = new Dictionary<string, ResourceDefinition>();
-            LoadDefinitionsAsync();
+            LoadDefinitionsAsync().Wait();
         }
 
-        public async Task LoadDefinitionsAsync()
+        public async Task LoadDefinitionsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            _definitions = await _definitionRepository.LoadResourceDefinitionsAsync();
+            _definitions = await _definitionRepository.LoadResourceDefinitionsAsync(cancellationToken);
 
 
             lock (_lock)
@@ -42,17 +45,24 @@ namespace SettlementTracker.Core.Services
             }
         }
 
-        public IReadOnlyList<ResourceDefinition> GetResourceDefinitions()
+        public IReadOnlyDictionary<string, ResourceDefinition> GetResourceDefinitions()
         {
-            return _definitions.Values.ToList();
+            lock (_lock)
+            {
+                return _definitions.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            }
         }
 
         public IReadOnlyDictionary<string, float> GetCurrentBalance()
         {
-            return _resources;
+            lock (_lock)
+            {
+                return _resources.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            }
         }
 
-        public async Task AddResourceAsync(string resourceId, float amount)
+        public async Task AddResourceAsync(string resourceId, float amount,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             ArgumentOutOfRangeException.ThrowIfNegative(amount);
             lock (_lock)
@@ -63,20 +73,26 @@ namespace SettlementTracker.Core.Services
                 _resources[resourceId] += amount;
             }
 
-            await OnResourcesChanged();
+            await OnResourcesChanged(cancellationToken);
         }
 
-        public async Task<bool> TrySpendResourceAsync(string resourceId, float amount)
+        public async Task<bool> TrySpendResourceAsync(string resourceId, float amount,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (!CanSpend(resourceId, amount))
-                return false;
-
             lock (_lock)
             {
-                _resources[resourceId] -= amount;
+                if (amount >= 0 && _resources.TryGetValue(resourceId, out float currentAmount) &&
+                    currentAmount >= amount)
+                {
+                    _resources[resourceId] -= amount;
+                }
+                else
+                {
+                    return false;
+                }
             }
 
-            await OnResourcesChanged();
+            await OnResourcesChanged(cancellationToken);
 
             return true;
         }
@@ -95,18 +111,13 @@ namespace SettlementTracker.Core.Services
 
         public event EventHandler<ResourcesChangedEventArgs>? ResourcesChanged;
 
-        public Task ApplyDailyEffectsAsync(IEnumerable<ResourceEffect> dailyEffects)
+        public Task ApplyDailyEffectsAsync(IEnumerable<ResourceEffect> dailyEffects,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }
 
-        private async Task OnResourcesChanged()
-        {
-            await SaveChangesAsync();
-            ResourcesChanged?.Invoke(this, new ResourcesChangedEventArgs(_resources));
-        }
-
-        public async Task SaveChangesAsync()
+        public async Task SaveStateAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var options = new JsonSerializerOptions { WriteIndented = true };
             string json;
@@ -116,25 +127,52 @@ namespace SettlementTracker.Core.Services
                 json = JsonSerializer.Serialize(_resources, options);
             }
 
-            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(_stateFilePath))!);
-            await File.WriteAllTextAsync(_stateFilePath, json);
+            Directory.CreateDirectory(_directoryName!);
+
+            await File.WriteAllTextAsync(_stateFilePath, json, cancellationToken);
         }
 
-        public async Task LoadFromFileAsync()
+        public async Task LoadStateAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             if (File.Exists(_stateFilePath))
             {
-                string json = await File.ReadAllTextAsync(_stateFilePath);
+                string json = await File.ReadAllTextAsync(_stateFilePath, cancellationToken);
 
                 lock (_lock)
                 {
-                    _resources = JsonSerializer.Deserialize<Dictionary<string, float>>(json) ??
-                                 new Dictionary<string, float>();
+                    var deserializeResources = JsonSerializer.Deserialize<Dictionary<string, float>>(json);
+                    if (deserializeResources != null)
+                    {
+                        foreach (KeyValuePair<string, float> deserializeResource in deserializeResources)
+                        {
+                            if (_definitions.ContainsKey(deserializeResource.Key))
+                            {
+                                if (!_resources.TryAdd(deserializeResource.Key, 0))
+                                {
+                                    _resources[deserializeResource.Key] = deserializeResource.Value;
+                                }
+                            }
+                            else
+                            {
+                                throw new ArgumentException("Unknown resource Id is loaded");
+                            }
+                        }
+                    }
+                    else
+                    {
+                        _resources = new Dictionary<string, float>();
+                        foreach (KeyValuePair<string, ResourceDefinition> deserializeResource in _definitions)
+                        {
+                            _resources[deserializeResource.Key] = 0;
+                        }
+                    }
                 }
             }
         }
 
-        public async Task SetResourceAsync(string resourceId, float amount)
+
+        public async Task SetResourceAsync(string resourceId, float amount,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             ArgumentOutOfRangeException.ThrowIfNegative(amount);
             lock (_lock)
@@ -145,7 +183,16 @@ namespace SettlementTracker.Core.Services
                 _resources[resourceId] = amount;
             }
 
-            await OnResourcesChanged();
+            await OnResourcesChanged(cancellationToken);
+        }
+
+        private async Task OnResourcesChanged(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await SaveStateAsync(cancellationToken);
+            lock (_lock)
+            {
+                ResourcesChanged?.Invoke(this, new ResourcesChangedEventArgs(_resources.ToDictionary()));
+            }
         }
     }
 }

--- a/SettlementTracker.WebInterface/Components/Layout/MainLayout.razor
+++ b/SettlementTracker.WebInterface/Components/Layout/MainLayout.razor
@@ -24,12 +24,12 @@
     </FooterSection>
 </BlazorBootstrapLayout>
 
-<ResourcesStatisticsPrototype @ref="_resourceStatistics"/>
+<ResourcesStatisticsPanel @ref="_resourceStatistics"/>
 
 @code
 {
     NavMenu _navMenu = default!;
-    ResourcesStatisticsPrototype _resourceStatistics = default!;
+    ResourcesStatisticsPanel _resourceStatistics = default!;
 }
 
 <div id="blazor-error-ui">

--- a/SettlementTracker.WebInterface/Components/Pages/ResourcesPages/ResourceStatisticsButton.razor
+++ b/SettlementTracker.WebInterface/Components/Pages/ResourcesPages/ResourceStatisticsButton.razor
@@ -1,6 +1,9 @@
 ﻿@using System.ComponentModel.Design
 @using SettlementTracker.Core.Managers
 @using SettlementTracker.WebInterface.Data.Services
+
+@inject ILogger<ResourceStatisticsButton> Logger
+
 <button @onclick="ToggleStatistics" class="btn btn-outline-info position-relative">
     <i class="bi bi-graph-up"></i>
     <span class="d-none d-md-inline ms-1">Ресурсы</span>
@@ -14,7 +17,7 @@
 
 @code {
     [Inject] private ISettlementResourcesService StatisticsService { get; set; } = default!;
-    [CascadingParameter(Name = "ResourcesStatisticsPanel")] private ResourcesStatisticsPrototype StatisticsPanel { get; set; }
+    [CascadingParameter(Name = "ResourcesStatisticsPanel")] private ResourcesStatisticsPanel StatisticsPanel { get; set; }
 
     private bool HasNewData { get; set; }
 
@@ -29,11 +32,13 @@
 
     private async Task ToggleStatistics()
     {
+        Logger.LogInformation("ToggleStatistics started");
         if (StatisticsPanel != null)
         {
             await StatisticsPanel.ShowAsync();
             HasNewData = false;
         }
+        Logger.LogInformation("ToggleStatistics finished");
     }
 
 }

--- a/SettlementTracker.WebInterface/Components/Pages/ResourcesPages/ResourcesStatisticsPanel.razor
+++ b/SettlementTracker.WebInterface/Components/Pages/ResourcesPages/ResourcesStatisticsPanel.razor
@@ -1,0 +1,213 @@
+﻿@rendermode InteractiveServer
+@using BlazorBootstrap
+@using SettlementTracker.Core.Managers
+@using SettlementTracker.Core.Models.Definitions
+@using SettlementTracker.WebInterface.Data.Services
+
+@inject ISettlementResourcesService ResourceService
+@inject ILogger<ResourcesStatisticsPanel> Logger
+
+@implements IDisposable
+
+<Offcanvas @ref="_offcanvas"
+           title="Ресурсы">
+    <HeaderTemplate>
+        <div class="d-flex justify-content-between align-items-center w-100">
+            <h5 class="mb-0">📊 Статистика ресурсов</h5>
+            <button type="button" class="btn-close" @onclick="HideAsync"></button>
+        </div>
+    </HeaderTemplate>
+    <BodyTemplate>
+        <div class="container-fluid">
+            <!-- Заголовок колонок (скрыт на мобильных) -->
+            <div class="row fw-bold d-none d-md-flex mb-2">
+                <div class="col-4">Ресурс</div>
+                <div class="col-2 text-end">Кол-во</div>
+                <div class="col-2 text-end">Изм.</div>
+                <div class="col-2 text-end">Дней запаса</div>
+                <div class="col-2 text-end">Действия</div>
+            </div>
+
+            @foreach (var resource in _resources)
+            {
+                <div class="row align-items-center mb-3 border-bottom pb-2">
+                    <!-- Название и иконка -->
+                    <div class="col-12 col-md-4">
+                        <Image Src="@resource.Icon" Alt="placeholder"/>
+                        <span class="fw-bold">@resource.Name</span>
+                    </div>
+
+                    <!-- Текущее количество -->
+                    <div class="col-6 col-md-2 text-start text-md-end">
+                        <span class="fs-5">@resource.CurrentAmount</span>
+                    </div>
+
+                    <!-- Изменение на следующий день -->
+                    <div class="col-6 col-md-2 text-start text-md-end">
+                        @if (resource.DailyChange > 0)
+                        {
+                            <span class="text-success">
+                                <i class="bi bi-arrow-up"></i> +@resource.DailyChange
+                            </span>
+                        }
+                        else if (resource.DailyChange < 0)
+                        {
+                            <span class="text-danger">
+                                <i class="bi bi-arrow-down"></i> @resource.DailyChange
+                            </span>
+                        }
+                        else
+                        {
+                            <span class="text-muted">
+                                <i class="bi bi-dash"></i> 0
+                            </span>
+                        }
+                    </div>
+
+                    <!-- Дней запаса -->
+                    <div class="col-6 col-md-2 text-start text-md-end">
+                        @if (resource.DailyChange < 0)
+                        {
+                            var days = (int)Math.Floor(resource.CurrentAmount / Math.Abs(resource.DailyChange));
+                            <span class="@(days < 3 ? "text-danger fw-bold" : "")">@days дн.</span>
+                        }
+                        else
+                        {
+                            <span class="text-muted">∞</span>
+                        }
+                    </div>
+
+                    <!-- Кнопки ручного изменения -->
+                    <div class="col-6 col-md-2 text-end">
+                        <Button Size="ButtonSize.Small" Color="ButtonColor.Success"
+                                @onclick=" async () => await IncrementAsync(resource.Id)">
+                            <i class="bi bi-plus"></i>
+                        </Button>
+                        <Button Size="ButtonSize.Small" Color="ButtonColor.Danger"
+                                class="ms-1" @onclick="async () => await DecrementAsync(resource.Id)"
+                                disabled="@(resource.CurrentAmount < 1)">
+                            <i class="bi bi-dash">
+                            </i>
+                        </Button>
+                    </div>
+                </div>
+            }
+
+            <!-- Пояснение -->
+            <div class="small text-muted mt-3">
+                <i class="bi bi-info-circle"></i> Дней запаса рассчитано при сохранении текущего изменения.
+            </div>
+        </div>
+    </BodyTemplate>
+</Offcanvas>
+
+@code {
+    private Offcanvas _offcanvas = default!;
+
+    public EventCallback OnShown { get; set; }
+
+    private async Task OnShowOffcanvasClick() => await _offcanvas.ShowAsync();
+
+    private async Task OnHideOffcanvasClick() => await _offcanvas.HideAsync();
+
+    private List<DisplayResource> _resources = new();
+
+    private IReadOnlyDictionary<string, ResourceDefinition> _resourcesDefinitions;
+    private IReadOnlyDictionary<string, float> _resourcesBalance;
+
+    protected override async Task OnInitializedAsync()
+    {
+        ResourceService.ResourcesChanged += OnResourcesChanged;
+
+        await ResourceService.LoadStateAsync();
+
+        OnUpdate();
+    }
+
+    private void OnResourcesChanged(object? sender, ResourcesChangedEventArgs e)
+    {
+        OnUpdate();
+        StateHasChanged();
+    }
+
+    private void OnUpdate()
+    {
+        _resourcesDefinitions = ResourceService.GetResourceDefinitions();
+        _resourcesBalance = ResourceService.GetCurrentBalance();
+
+        CreateResourcesList();
+    }
+
+    private void CreateResourcesList()
+    {
+        _resources.Clear();
+
+        foreach (var resourceData in _resourcesBalance)
+        {
+            if (!_resourcesDefinitions.TryGetValue(resourceData.Key, out var definition))
+            {
+                Logger.LogWarning($"Nonexistent definition {definition} requested");
+                continue;
+            }
+
+            _resources.Add(new DisplayResource()
+            {
+                Id = resourceData.Key,
+                Icon = definition.IconPath,
+                CurrentAmount = resourceData.Value,
+                DailyChange = 0, // Пока не реализована агрегация Resource effect задана 0
+                Name = definition.Name
+            });
+        }
+    }
+
+    public async Task ShowAsync()
+    {
+        await _offcanvas.ShowAsync();
+        await OnShown.InvokeAsync();
+    }
+
+    public async Task HideAsync()
+    {
+        await _offcanvas.HideAsync();
+    }
+
+    private async Task IncrementAsync(string resourceId)
+    {
+        try
+        {
+            await ResourceService.AddResourceAsync(resourceId, 1);
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, $"Failed to increment resource {resourceId}", resourceId);
+        }
+    }
+
+    private async Task DecrementAsync(string resourceId)
+    {
+        try
+        {
+            await ResourceService.TrySpendResourceAsync(resourceId, 1);
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, $"Failed to decrement resource {resourceId}", resourceId);
+        }
+    }
+
+    public void Dispose()
+    {
+        ResourceService.ResourcesChanged -= OnResourcesChanged;
+    }
+
+    private class DisplayResource
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Icon { get; set; } = string.Empty;
+        public float CurrentAmount { get; set; }
+        public float DailyChange { get; set; }
+    }
+
+}

--- a/SettlementTracker.WebInterface/Data/resourcesDefinition.json
+++ b/SettlementTracker.WebInterface/Data/resourcesDefinition.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "food",
+    "name": "\u0415\u0434\u0430",
+    "description": "\u041E\u0441\u043D\u043E\u0432\u043D\u043E\u0439 \u043F\u0438\u0449\u0435\u0432\u043E\u0439 \u0440\u0435\u0441\u0443\u0440\u0441",
+    "iconPath": "/images/Icons/food.png",
+    "isConsumable": true
+  },
+  {
+    "id": "wood",
+    "name": "\u0414\u0440\u0435\u0432\u0435\u0441\u0438\u043D\u0430",
+    "description": "\u0421\u0442\u0440\u043E\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u0439 \u043C\u0430\u0442\u0435\u0440\u0438\u0430\u043B",
+    "iconPath": "/images/Icons/wood.png",
+    "isConsumable": false
+  },
+  {
+    "id": "stone",
+    "name": "\u041A\u0430\u043C\u0435\u043D\u044C",
+    "description": "\u0421\u0442\u0440\u043E\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u0439 \u043C\u0430\u0442\u0435\u0440\u0438\u0430\u043B",
+    "iconPath": "/images/Icons/stone.png",
+    "isConsumable": false
+  },
+  {
+    "id": "water",
+    "name": "\u0412\u043E\u0434\u0430",
+    "description": "\u041F\u0438\u0442\u044C\u0435\u0432\u0430\u044F \u0432\u043E\u0434\u0430",
+    "iconPath": "/images/Icons/water.png",
+    "isConsumable": true
+  }
+]

--- a/SettlementTracker.WebInterface/Program.cs
+++ b/SettlementTracker.WebInterface/Program.cs
@@ -11,6 +11,15 @@ public class Program
     {
         WebApplicationBuilder? builder = WebApplication.CreateBuilder(args);
 
+        // Настройка логирования
+        builder.Logging.ClearProviders(); // очищаем стандартные (необязательно)
+        builder.Logging.AddConsole(); // вывод в консоль
+        builder.Logging.AddDebug(); // вывод в окно отладки
+
+// Установка минимального уровня логирования для всего приложения
+// TODO: Change to Error before pull-request
+        builder.Logging.SetMinimumLevel(LogLevel.Trace);
+
         builder.Services.AddBlazorBootstrap();
 
         // Add services to the container.
@@ -20,7 +29,7 @@ public class Program
         builder.Services.AddSingleton<ICitizenService, CitizenService>();
         builder.Services.AddSingleton<IBuildingService, BuildingService>();
         builder.Services.AddSingleton<ISettlementResourcesService>(
-            new SettlementResourcesService(new JsonDefinitionRepository("State")));
+            new SettlementResourcesService(new JsonDefinitionRepository("Data")));
 
 
         WebApplication? app = builder.Build();


### PR DESCRIPTION
## Описание изменений

- Создан полноценный компонент ResourcesStatistics.razor, который получает данные из сервиса SettlementResourcesService и отображает актуальную информацию о балансе ресурсов поселения и прогнозе их изменения.
- Исправлены пути к файлы с определениями ресурсов
- Сигнатуры функций сохранения и загрузки состояния и задания конкретного количества ресурсов перенесены в `ISettlementResourcesService`

## Тип изменения

<!-- Удалите нерелевантные пункты. -->

- [x] 🐛 Исправление бага (не ломающее обратную совместимость)
- [x] ✨ Новая функциональность (не ломающее обратную совместимость)
- [x] 🎨 Стиль кода (форматирование, локальные переменные)

## Ссылка на задачу

Закрывает https://github.com/BelyaevPavel/SettlementTracker/issues/3

## Как это можно протестировать?

**Шаги для тестирования:**
1. Запустить WebInterface
2. Открыть панель ресурсов, нажав на кнопку Статистика на верхней панели
3. Убедиться, что на панели отображаются те ресурсы, определения которых есть в `Data\resourcesDefinition.json`
4. Запомнить текущее количество и внести какие-либо изменения
5. Убедиться в корректном сохранении состояния, сравнив содержимое файла `State\resources.json` с отображаемым на панели
6. Перезапустить сервер и убедиться, что состояние корректно загрузилось сравнив числа с запомненными

## Проверочный чек-лист

- [x] Мой код соответствует стилю кода этого проекта
- [x] Я провел(а) саморевью своего кода
- [ ] Я прокомментировал(а) свой код в трудночитаемых местах
- [ ] Я обновил(а) документацию (если это необходимо)
- [ ] Я добавил(а) тесты, которые покрывают мои изменения
- [x] Все существующие и новые тесты проходят локально
- [x] Мой измененный код не ломает сборку и не вызывает ошибок линтеров

## Дополнительные сведения
Из-за отсутствия сборки `ResourceEffect` прогноз показывает 0, но работает корректно при предоставлении данных