### PR TITLE
Реализован TryApplyResourceEffectAsync в сервисе SettlementResourcesService

### DIFF
--- a/SettlementTracker.Core.Tests/Data/Services/SettlementResourcesServiceTest.cs
+++ b/SettlementTracker.Core.Tests/Data/Services/SettlementResourcesServiceTest.cs
@@ -282,7 +282,108 @@ public class SettlementResourcesServiceTest
     {
         // Act & Assert
         Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            await _service.ApplyDailyEffectsAsync(null));
+            await _service.TryApplyResourceEffectAsync(null));
+    }
+
+    [Test]
+    public async Task TryApplyDailyEffectsAsync_ProductionEffect_ExistingResource_ShouldIncreaseResourceAndReturnTrue()
+    {
+        // Arrange
+        const string resourceId = "wood";
+        const float initialAmount = 10f;
+        const float effectAmount = 5f;
+        await _service.SetResourceAsync(resourceId, initialAmount);
+
+        var effect = new ResourceEffect
+        {
+            ResourceId = resourceId,
+            Amount = effectAmount,
+            IsProduction = true
+        };
+
+        // Act
+        bool result = await _service.TryApplyResourceEffectAsync(effect, CancellationToken.None);
+        float resultAmount = _service.GetCurrentBalance()["wood"];
+
+        // Assert
+        Assert.That(result, Is.True, "Method should return true for successful production.");
+        Assert.That(resultAmount, Is.EqualTo(initialAmount + effectAmount),
+            "Resource amount should increase by production amount.");
+    }
+
+    [Test]
+    public async Task TryApplyDailyEffectsAsync_ConsumptionEffect_ExistingResource_ShouldIncreaseResourceAndReturnTrue()
+    {
+        // Arrange
+        const string resourceId = "wood";
+        const float initialAmount = 10f;
+        const float effectAmount = 5f;
+        await _service.SetResourceAsync(resourceId, initialAmount);
+
+        var effect = new ResourceEffect
+        {
+            ResourceId = resourceId,
+            Amount = effectAmount,
+            IsProduction = false //Consumption
+        };
+
+        // Act
+        bool result = await _service.TryApplyResourceEffectAsync(effect, CancellationToken.None);
+        float resultAmount = _service.GetCurrentBalance()["wood"];
+
+        // Assert
+        Assert.That(result, Is.True, "Method should return true for successful production.");
+        Assert.That(resultAmount, Is.EqualTo(initialAmount - effectAmount),
+            "Resource amount should increase by production amount.");
+    }
+
+    [Test]
+    public async Task
+        TryApplyDailyEffectsAsync_ConsumptionEffect_InsufficientResource_ShouldReturnFalseAndNotChangeResource()
+    {
+        // Arrange
+        const string resourceId = "wood";
+        const float initialAmount = 2f;
+        const float effectAmount = 5f;
+        await _service.SetResourceAsync(resourceId, initialAmount);
+
+        var effect = new ResourceEffect
+        {
+            ResourceId = resourceId,
+            Amount = effectAmount,
+            IsProduction = false //Consumption
+        };
+
+        // Act
+        bool result = await _service.TryApplyResourceEffectAsync(effect, CancellationToken.None);
+        float resultAmount = _service.GetCurrentBalance()["wood"];
+
+        // Assert
+        Assert.That(result, Is.False, "Method should return true for successful consumption.");
+        Assert.That(resultAmount, Is.EqualTo(initialAmount),
+            "Resource amount should increase by consumption amount.");
+    }
+
+    [Test]
+    public async Task TryApplyDailyEffectsAsync_EffectForNonExistingResource_ShouldReturnFalse()
+    {
+        // Arrange
+        const string resourceId = "nonexistent";
+        const float effectAmount = 5f;
+
+        var effect = new ResourceEffect
+        {
+            ResourceId = resourceId,
+            Amount = effectAmount,
+            IsProduction = false //Consumption
+        };
+
+        // Act
+        bool result = await _service.TryApplyResourceEffectAsync(effect, CancellationToken.None);
+        float resultAmount = _service.GetCurrentBalance()["wood"];
+
+        // Assert
+        Assert.That(result, Is.False, "Method should return false for non-existing resource.");
     }
 
     [Test]
@@ -298,6 +399,32 @@ public class SettlementResourcesServiceTest
         Assert.That(balance.Keys, Is.EquivalentTo(new[] { "wood", "stone" }));
         Assert.That(balance["wood"], Is.EqualTo(0));
         Assert.That(balance["stone"], Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task TryApplyDailyEffectsAsync_CancelledToken_ShouldThrowOperationCanceledException()
+    {
+        // Arrange
+        const string resourceId = "wood";
+        const float initialAmount = 10f;
+        const float effectAmount = 5f;
+
+        await _service.SetResourceAsync(resourceId, initialAmount);
+
+        var effect = new ResourceEffect
+        {
+            ResourceId = resourceId,
+            Amount = effectAmount,
+            IsProduction = true
+        };
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act & Assert
+        Assert.That(async () => await _service.TryApplyResourceEffectAsync(effect, cts.Token),
+            Throws.InstanceOf<OperationCanceledException>(),
+            "Method should propagate cancellation if OnResourcesChanged supports it.");
     }
 
     [Test]

--- a/SettlementTracker.Core/Services/ISettlementResourcesService.cs
+++ b/SettlementTracker.Core/Services/ISettlementResourcesService.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using SettlementTracker.Core.Managers;
 using SettlementTracker.Core.Models.Definitions;
 
-namespace SettlementTracker.WebInterface.Data.Services
+namespace SettlementTracker.Core.Services
 {
     public interface ISettlementResourcesService
     {
@@ -13,28 +13,28 @@ namespace SettlementTracker.WebInterface.Data.Services
         ///     Loads JSON from standard file path.
         /// </summary>
         /// <returns></returns>
-        Task LoadDefinitionsAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task LoadDefinitionsAsync(CancellationToken cancellationToken = default);
 
-        Task SaveStateAsync(CancellationToken cancellationToken = default(CancellationToken));
-        Task LoadStateAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task SaveStateAsync(CancellationToken cancellationToken = default);
+        Task LoadStateAsync(CancellationToken cancellationToken = default);
 
         IReadOnlyDictionary<string, ResourceDefinition> GetResourceDefinitions();
         IReadOnlyDictionary<string, float> GetCurrentBalance();
 
 
         Task SetResourceAsync(string resourceId, float amount,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         Task AddResourceAsync(string resourceId, float amount,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         Task<bool> TrySpendResourceAsync(string resourceId, float amount,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         bool CanSpend(string resourceId, float amount);
         event EventHandler<ResourcesChangedEventArgs> ResourcesChanged;
 
-        Task ApplyDailyEffectsAsync(IEnumerable<ResourceEffect> dailyEffects,
-            CancellationToken cancellationToken = default(CancellationToken));
+        Task<bool> TryApplyResourceEffectAsync(ResourceEffect dailyEffects,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/SettlementTracker.Core/Services/SettlementResourcesService.cs
+++ b/SettlementTracker.Core/Services/SettlementResourcesService.cs
@@ -5,21 +5,21 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using SettlementTracker.Core.Managers;
 using SettlementTracker.Core.Models.Definitions;
 using SettlementTracker.Core.Repositories;
-using SettlementTracker.WebInterface.Data.Services;
 
 namespace SettlementTracker.Core.Services
 {
     public class SettlementResourcesService : ISettlementResourcesService
     {
         private readonly IResourceDefinitionRepository _definitionRepository;
+        private readonly string _directoryName;
         private readonly object _lock = new();
         private readonly string _stateFilePath;
         private Dictionary<string, ResourceDefinition> _definitions;
         private Dictionary<string, float> _resources;
-        private readonly string _directoryName;
 
         public SettlementResourcesService(IResourceDefinitionRepository definitionRepository,
             string stateFilePath = "State\\resources.json")
@@ -32,7 +32,9 @@ namespace SettlementTracker.Core.Services
             LoadDefinitionsAsync().Wait();
         }
 
-        public async Task LoadDefinitionsAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public ILogger<SettlementResourcesService>? Logger { get; set; }
+
+        public async Task LoadDefinitionsAsync(CancellationToken cancellationToken = default)
         {
             _definitions = await _definitionRepository.LoadResourceDefinitionsAsync(cancellationToken);
 
@@ -62,7 +64,7 @@ namespace SettlementTracker.Core.Services
         }
 
         public async Task AddResourceAsync(string resourceId, float amount,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(amount);
             lock (_lock)
@@ -77,19 +79,15 @@ namespace SettlementTracker.Core.Services
         }
 
         public async Task<bool> TrySpendResourceAsync(string resourceId, float amount,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             lock (_lock)
             {
                 if (amount >= 0 && _resources.TryGetValue(resourceId, out float currentAmount) &&
                     currentAmount >= amount)
-                {
                     _resources[resourceId] -= amount;
-                }
                 else
-                {
                     return false;
-                }
             }
 
             await OnResourcesChanged(cancellationToken);
@@ -111,13 +109,83 @@ namespace SettlementTracker.Core.Services
 
         public event EventHandler<ResourcesChangedEventArgs>? ResourcesChanged;
 
-        public Task ApplyDailyEffectsAsync(IEnumerable<ResourceEffect> dailyEffects,
-            CancellationToken cancellationToken = default(CancellationToken))
+        /// <summary>
+        ///     Пытается применить эффект ресурса (производство или потребление) к текущему балансу.
+        /// </summary>
+        /// <param name="resourceEffect">
+        ///     Эффект ресурса, содержащий идентификатор ресурса, величину и признак
+        ///     производства/потребления.
+        /// </param>
+        /// <param name="cancellationToken">Токен отмены для асинхронной операции сохранения.</param>
+        /// <returns>
+        ///     true, если эффект успешно применён; false, если ресурс не найден (отсутствует определение или запись о балансе)
+        ///     либо для нерасходуемого ресурса (IsConsumable = false) недостаточно средств.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Выбрасывается, если <paramref name="resourceEffect" /> равен null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Выбрасывается, если <paramref name="resourceEffect.Amount" /> неположителен.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        ///     Выбрасывается, если операция отменена через
+        ///     <paramref name="cancellationToken" /> во время сохранения состояния.
+        /// </exception>
+        /// <remarks>
+        ///     Метод учитывает признак <see cref="ResourceEffect.IsProduction" />:
+        ///     <list type="bullet">
+        ///         <item>
+        ///             <description>Если <c>true</c>, величина добавляется к балансу (производство).</description>
+        ///         </item>
+        ///         <item>
+        ///             <description>Если <c>false</c>, величина вычитается из баланса (потребление).</description>
+        ///         </item>
+        ///     </list>
+        ///     Для ресурсов с флагом <see cref="ResourceDefinition.IsConsumable" />, равным <c>false</c>, проверяется,
+        ///     что итоговый баланс не станет отрицательным.
+        ///     <para>
+        ///         При успешном изменении вызывается событие <see cref="ResourcesChanged" /> и состояние асинхронно сохраняется в
+        ///         файл с помощью <see cref="SaveStateAsync" />.
+        ///     </para>
+        ///     <para>
+        ///         Все операции с внутренним словарём ресурсов выполняются под блокировкой для обеспечения потокобезопасности.
+        ///     </para>
+        /// </remarks>
+        public async Task<bool> TryApplyResourceEffectAsync(ResourceEffect resourceEffect,
+            CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            if (resourceEffect == null) throw new ArgumentNullException(nameof(resourceEffect));
+            if (resourceEffect.Amount <= 0) throw new ArgumentOutOfRangeException(nameof(resourceEffect));
+            if (!_definitions.ContainsKey(resourceEffect.ResourceId))
+            {
+                Logger?.LogWarning("Resource definition for resourceId {resourceId} not found",
+                    resourceEffect.ResourceId);
+                return false;
+            }
+
+
+            float amount = resourceEffect.IsProduction ? resourceEffect.Amount : -resourceEffect.Amount;
+            string resourceId = resourceEffect.ResourceId;
+
+            lock (_lock)
+            {
+                if (_resources.TryGetValue(resourceId, out float currentAmount))
+                {
+                    if (currentAmount + amount >= 0)
+                        _resources[resourceId] += amount;
+                    else
+                        return false;
+                }
+                else
+                {
+                    Logger?.LogWarning("Resource for resourceId {resourceId} not found", resourceEffect.ResourceId);
+                    return false;
+                }
+            }
+
+            await OnResourcesChanged(cancellationToken);
+            return true;
         }
 
-        public async Task SaveStateAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public async Task SaveStateAsync(CancellationToken cancellationToken = default)
         {
             var options = new JsonSerializerOptions { WriteIndented = true };
             string json;
@@ -132,7 +200,7 @@ namespace SettlementTracker.Core.Services
             await File.WriteAllTextAsync(_stateFilePath, json, cancellationToken);
         }
 
-        public async Task LoadStateAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public async Task LoadStateAsync(CancellationToken cancellationToken = default)
         {
             if (File.Exists(_stateFilePath))
             {
@@ -144,27 +212,21 @@ namespace SettlementTracker.Core.Services
                     if (deserializeResources != null)
                     {
                         foreach (KeyValuePair<string, float> deserializeResource in deserializeResources)
-                        {
                             if (_definitions.ContainsKey(deserializeResource.Key))
                             {
                                 if (!_resources.TryAdd(deserializeResource.Key, 0))
-                                {
                                     _resources[deserializeResource.Key] = deserializeResource.Value;
-                                }
                             }
                             else
                             {
                                 throw new ArgumentException("Unknown resource Id is loaded");
                             }
-                        }
                     }
                     else
                     {
                         _resources = new Dictionary<string, float>();
                         foreach (KeyValuePair<string, ResourceDefinition> deserializeResource in _definitions)
-                        {
                             _resources[deserializeResource.Key] = 0;
-                        }
                     }
                 }
             }
@@ -172,7 +234,7 @@ namespace SettlementTracker.Core.Services
 
 
         public async Task SetResourceAsync(string resourceId, float amount,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(amount);
             lock (_lock)
@@ -186,7 +248,7 @@ namespace SettlementTracker.Core.Services
             await OnResourcesChanged(cancellationToken);
         }
 
-        private async Task OnResourcesChanged(CancellationToken cancellationToken = default(CancellationToken))
+        private async Task OnResourcesChanged(CancellationToken cancellationToken = default)
         {
             await SaveStateAsync(cancellationToken);
             lock (_lock)

--- a/SettlementTracker.Core/SettlementTracker.Core.csproj
+++ b/SettlementTracker.Core/SettlementTracker.Core.csproj
@@ -5,4 +5,8 @@
         <LangVersion>9</LangVersion>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2"/>
+    </ItemGroup>
+
 </Project>

--- a/SettlementTracker.WebInterface/Components/Pages/ResourcesPages/ResourceStatisticsButton.razor
+++ b/SettlementTracker.WebInterface/Components/Pages/ResourcesPages/ResourceStatisticsButton.razor
@@ -1,7 +1,4 @@
-﻿@using System.ComponentModel.Design
-@using SettlementTracker.Core.Managers
-@using SettlementTracker.WebInterface.Data.Services
-
+﻿@using SettlementTracker.Core.Services
 @inject ILogger<ResourceStatisticsButton> Logger
 
 <button @onclick="ToggleStatistics" class="btn btn-outline-info position-relative">
@@ -17,7 +14,9 @@
 
 @code {
     [Inject] private ISettlementResourcesService StatisticsService { get; set; } = default!;
-    [CascadingParameter(Name = "ResourcesStatisticsPanel")] private ResourcesStatisticsPanel StatisticsPanel { get; set; }
+
+[CascadingParameter(Name = "ResourcesStatisticsPanel")]
+private ResourcesStatisticsPanel StatisticsPanel { get; set; }
 
     private bool HasNewData { get; set; }
 
@@ -38,7 +37,8 @@
             await StatisticsPanel.ShowAsync();
             HasNewData = false;
         }
-        Logger.LogInformation("ToggleStatistics finished");
+
+    Logger.LogInformation("ToggleStatistics finished");
     }
 
 }

--- a/SettlementTracker.WebInterface/Components/Pages/ResourcesPages/ResourcesStatisticsPanel.razor
+++ b/SettlementTracker.WebInterface/Components/Pages/ResourcesPages/ResourcesStatisticsPanel.razor
@@ -1,12 +1,12 @@
 ﻿@rendermode InteractiveServer
-@using BlazorBootstrap
-@using SettlementTracker.Core.Managers
-@using SettlementTracker.Core.Models.Definitions
-@using SettlementTracker.WebInterface.Data.Services
 
 @inject ISettlementResourcesService ResourceService
 @inject ILogger<ResourcesStatisticsPanel> Logger
 
+@using BlazorBootstrap
+@using SettlementTracker.Core.Managers
+@using SettlementTracker.Core.Models.Definitions
+@using SettlementTracker.Core.Services
 @implements IDisposable
 
 <Offcanvas @ref="_offcanvas"
@@ -28,7 +28,7 @@
                 <div class="col-2 text-end">Действия</div>
             </div>
 
-            @foreach (var resource in _resources)
+            @foreach (DisplayResource resource in _resources)
             {
                 <div class="row align-items-center mb-3 border-bottom pb-2">
                     <!-- Название и иконка -->
@@ -106,9 +106,15 @@
 
     public EventCallback OnShown { get; set; }
 
-    private async Task OnShowOffcanvasClick() => await _offcanvas.ShowAsync();
+private async Task OnShowOffcanvasClick()
+{
+await _offcanvas.ShowAsync();
+}
 
-    private async Task OnHideOffcanvasClick() => await _offcanvas.HideAsync();
+private async Task OnHideOffcanvasClick()
+{
+await _offcanvas.HideAsync();
+}
 
     private List<DisplayResource> _resources = new();
 
@@ -142,15 +148,15 @@
     {
         _resources.Clear();
 
-        foreach (var resourceData in _resourcesBalance)
+    foreach (KeyValuePair<string, float> resourceData in _resourcesBalance)
         {
-            if (!_resourcesDefinitions.TryGetValue(resourceData.Key, out var definition))
+        if (!_resourcesDefinitions.TryGetValue(resourceData.Key, out ResourceDefinition? definition))
             {
                 Logger.LogWarning($"Nonexistent definition {definition} requested");
                 continue;
             }
 
-            _resources.Add(new DisplayResource()
+        _resources.Add(new DisplayResource
             {
                 Id = resourceData.Key,
                 Icon = definition.IconPath,

--- a/SettlementTracker.WebInterface/Program.cs
+++ b/SettlementTracker.WebInterface/Program.cs
@@ -1,7 +1,6 @@
 ﻿using SettlementTracker.Core.Repositories;
 using SettlementTracker.Core.Services;
 using SettlementTracker.WebInterface.Components;
-using SettlementTracker.WebInterface.Data.Services;
 
 namespace SettlementTracker.WebInterface;
 


### PR DESCRIPTION
## Описание изменений

В данном PR реализован метод `TryApplyResourceEffectAsync` в сервисе `SettlementResourcesService`, который заменяет ранее нереализованный `ApplyDailyEffectsAsync`. Теперь эффекты ресурсов (производство/потребление) применяются с проверкой достаточности средств для потребления, поддержкой отмены операции и логированием. Также проведён рефакторинг: интерфейс перенесён в правильное пространство имён `SettlementTracker.Core.Services`, добавлена зависимость `ILogger`, исправлены ссылки в Blazor-компонентах. Написаны модульные тесты, покрывающие все ключевые сценарии работы нового метода.

## Тип изменения

- ✨ Новая функциональность (не ломающее обратную совместимость)
- ♻️ Рефакторинг (без изменения функциональности)
- 🎨 Стиль кода (форматирование, локальные переменные)
- 🧪 Тесты

## Ссылка на задачу

Нет

## Как это можно протестировать?

**Шаги для тестирования (через модульные тесты):**
1. Запустить все тесты из класса `SettlementResourcesServiceTest`.
2. Убедиться, что новые тесты `TryApplyDailyEffectsAsync_*` проходят успешно:
   - Производство существующего ресурса увеличивает баланс.
   - Потребление существующего ресурса уменьшает баланс.
   - При недостатке ресурса потребление не происходит, метод возвращает `false`.
   - Для несуществующего ресурса метод возвращает `false`.
 
## Проверочный чек-лист

<!-- Отметьте галочками пункты, которые вы выполнили. -->

- [x] Мой код соответствует стилю кода этого проекта
- [x] Я провел(а) саморевью своего кода
- [x] Я прокомментировал(а) свой код в трудночитаемых местах
- [x] Я обновил(а) документацию (если это необходимо)
- [x] Я добавил(а) тесты, которые покрывают мои изменения
- [x] Все существующие и новые тесты проходят локально
- [x] Мой измененный код не ломает сборку и не вызывает ошибок линтеров
