### PR TITLE
Deadlock fix on SettlementResourcesService creation

### DIFF
--- a/SettlementTracker.Core/Services/SettlementResourcesService.cs
+++ b/SettlementTracker.Core/Services/SettlementResourcesService.cs
@@ -29,7 +29,7 @@ namespace SettlementTracker.Core.Services
             _directoryName = Path.GetDirectoryName(Path.GetFullPath(_stateFilePath));
             _resources = new Dictionary<string, float>();
             _definitions = new Dictionary<string, ResourceDefinition>();
-            LoadDefinitionsAsync().Wait();
+            LoadDefinitions();
         }
 
         public ILogger<SettlementResourcesService>? Logger { get; set; }
@@ -246,6 +246,18 @@ namespace SettlementTracker.Core.Services
             }
 
             await OnResourcesChanged(cancellationToken);
+        }
+
+        private void LoadDefinitions()
+        {
+            _definitions = _definitionRepository.LoadResourceDefinitions();
+
+            lock (_lock)
+            {
+                _resources = new Dictionary<string, float>();
+                foreach (ResourceDefinition resourceDef in _definitions.Values)
+                    _resources[resourceDef.Id] = 0;
+            }
         }
 
         private async Task OnResourcesChanged(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Описание изменений

Исправлен deadlock при создании `SettlementResourcesService`. В конструкторе сервиса ранее вызывался асинхронный метод `LoadDefinitionsAsync().Wait()`, что могло привести к взаимной блокировке в среде с синхронизационным контекстом. Теперь загрузка определений ресурсов выполняется синхронно через новый метод `LoadDefinitions()`, который не блокирует поток и не вызывает deadlock.
В будущем планируется заменить это на ленивую инициализацию или другой более безопасный подход.

## Тип изменения

<!-- Удалите нерелевантные пункты. -->

- 🐛 Исправление бага (не ломающее обратную совместимость)

## Ссылка на задачу

Нет

## Как это можно протестировать?

**Шаги для тестирования:**
Запустить приложение, в котором используется SettlementResourcesService (например, при старте системы).

1. Убедиться, что сервис успешно инициализируется без зависаний.
2. Проверить, что загруженные определения ресурсов доступны и соответствуют ожидаемым.


## Проверочный чек-лист

- [x] Мой код соответствует стилю кода этого проекта
- [x] Я провел(а) саморевью своего кода
- [x] Я прокомментировал(а) свой код в трудночитаемых местах
- [x] Я обновил(а) документацию (если это необходимо)
- [ ] Я добавил(а) тесты, которые покрывают мои изменения
- [x] Все существующие и новые тесты проходят локально
- [x] Мой измененный код не ломает сборку и не вызывает ошибок линтеров
